### PR TITLE
Add Explicit casting | Support for newer DMD Compiler

### DIFF
--- a/Samples/Chap04/SysMets1/SysMets1.d
+++ b/Samples/Chap04/SysMets1/SysMets1.d
@@ -174,7 +174,7 @@ int myWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int
         DispatchMessage(&msg);
     }
 
-    return msg.wParam;
+    return cast(int)msg.wParam;
 }
 
 extern(Windows)
@@ -215,16 +215,16 @@ LRESULT WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) nothrow
 
             foreach (index, metric; sysMetrics)
             {
-                y = cyChar * (index - iVScrollPos);
+                y = cast(int)(cyChar * (index - cast(int)iVScrollPos));
 
-                TextOut(hdc, 0, y, metric.label.toUTF16z, metric.label.count);
-                TextOut(hdc, 22 * cxCaps, y, metric.desc.toUTF16z, metric.desc.count);
+                TextOut(hdc, 0, y, metric.label.toUTF16z, cast(int)metric.label.count);
+                TextOut(hdc, 22 * cxCaps, y, metric.desc.toUTF16z, cast(int)metric.desc.count);
 
                 string value = to!string(GetSystemMetrics(metric.index));
 
                 // right-align
                 SetTextAlign(hdc, TA_RIGHT | TA_TOP);
-                TextOut(hdc, 22 * cxCaps + 40 * cxChar, y, value.toUTF16z, value.count);
+                TextOut(hdc, 22 * cxCaps + 40 * cxChar, y, value.toUTF16z, cast(int)value.count);
 
                 // restore alignment
                 SetTextAlign(hdc, TA_LEFT | TA_TOP);


### PR DESCRIPTION
Takes care of these errors:

```
sample.d(177): Error: cannot implicitly convert expression `msg.wParam` of type `ulong` to `int`
sample.d(218): Error: cannot implicitly convert expression `cast(ulong)cyChar * (index - cast(ulong)iVScrollPos)` of type `ulong` to `int`
sample.d(220): Error: function `core.sys.windows.wingdi.TextOutW(void*, int, int, const(wchar)*, int)` is not callable using argument types `(void*, int, int, const(wchar)*, ulong)`
sample.d(220):        cannot pass argument `count(cast(const(char)[])metric.label)` of type `ulong` to parameter `int`
sample.d(221): Error: function `core.sys.windows.wingdi.TextOutW(void*, int, int, const(wchar)*, int)` is not callable using argument types `(void*, int, int, const(wchar)*, ulong)`
sample.d(221):        cannot pass argument `count(cast(const(char)[])metric.desc)` of type `ulong` to parameter `int`
sample.d(227): Error: function `core.sys.windows.wingdi.TextOutW(void*, int, int, const(wchar)*, int)` is not callable using argument types `(void*, int, int, const(wchar)*, ulong)`
sample.d(227):        cannot pass argument `count(cast(const(char)[])value)` of type `ulong` to parameter `int`
Failed: ["C:\\Program Files\\LDC 1.28\\bin\\ldmd2.exe", "-v", "-o-", "sample.d", "-I."]
```